### PR TITLE
Fix issues wrapper sdk exception manager

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+codecov:
+  bot: xabldint

--- a/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -77,14 +77,20 @@ public class WrapperSdkExceptionManagerAndroidTest {
             }
         }
 
-        // even after deleting errorA, it should exist in memory - so, we can still load it
+        /* Even after deleting errorA, it should exist in memory - so, we can still load it. */
         WrapperSdkExceptionManager.deleteWrapperExceptionData(errorA.id);
         byte[] loadedDataA = WrapperSdkExceptionManager.loadWrapperExceptionData(errorA.id);
         assertNotNull(loadedDataA);
-
         for (int i = 0; i < errorA.data.length; ++i) {
             assertEquals(errorA.data[i], loadedDataA[i]);
         }
-    }
 
+        /* Try to load data bypassing the cache. */
+        WrapperSdkExceptionManager.sWrapperExceptionDataContainer.clear();
+        byte[] loadedDataC = WrapperSdkExceptionManager.loadWrapperExceptionData(errorC.id);
+        assertNotNull(loadedDataC);
+        for (int i = 0; i < errorC.data.length; ++i) {
+            assertEquals(errorC.data[i], loadedDataC[i]);
+        }
+    }
 }

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManager.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManager.java
@@ -25,6 +25,7 @@ public class WrapperSdkExceptionManager {
      */
     @VisibleForTesting
     static final Map<String, byte[]> sWrapperExceptionDataContainer = new HashMap<>();
+
     /**
      * File extension for data files created by this class.
      */

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManager.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManager.java
@@ -21,14 +21,14 @@ import java.util.UUID;
 public class WrapperSdkExceptionManager {
 
     /**
+     * Contains wrapper SDK data that has been loaded into memory
+     */
+    @VisibleForTesting
+    static final Map<String, byte[]> sWrapperExceptionDataContainer = new HashMap<>();
+    /**
      * File extension for data files created by this class.
      */
     private static final String DATA_FILE_EXTENSION = ".dat";
-
-    /**
-     * Contains wrapper SDK data that has been loaded into memory
-     */
-    private static final Map<String, byte[]> sWrapperExceptionDataContainer = new HashMap<>();
 
     @VisibleForTesting
     WrapperSdkExceptionManager() {
@@ -37,7 +37,7 @@ public class WrapperSdkExceptionManager {
     /**
      * Store the in-memory wrapper exception data to disk. This should only be used by a wrapper SDK.
      *
-     * @param data  The data to be saved
+     * @param data    The data to be saved
      * @param errorId The associated error UUID
      */
     public static void saveWrapperExceptionData(byte[] data, UUID errorId) {
@@ -50,8 +50,7 @@ public class WrapperSdkExceptionManager {
         File dataFile = getFile(errorId);
         try {
             StorageHelper.InternalStorage.writeObject(dataFile, data);
-        }
-        catch (IOException e) {
+        } catch (IOException e) {
             MobileCenterLog.error(Crashes.LOG_TAG, "Failed to save wrapper exception data to file", e);
         }
     }
@@ -59,27 +58,27 @@ public class WrapperSdkExceptionManager {
     /**
      * Delete wrapper exception data from disk and store it in memory
      *
-     * @param errorId    The associated error UUID
+     * @param errorId The associated error UUID
      */
     public static void deleteWrapperExceptionData(UUID errorId) {
         if (errorId == null) {
             MobileCenterLog.error(Crashes.LOG_TAG, "Failed to delete wrapper exception data: null errorId");
             return;
         }
-
         File dataFile = getFile(errorId);
-        byte[] loadResult = loadWrapperExceptionData(errorId);
-        if (loadResult == null) {
-            MobileCenterLog.error(Crashes.LOG_TAG, "Failed to delete wrapper exception data: data not found");
-            return;
+        if (dataFile.exists()) {
+            byte[] loadResult = loadWrapperExceptionData(errorId);
+            if (loadResult == null) {
+                MobileCenterLog.error(Crashes.LOG_TAG, "Failed to delete wrapper exception data: data not found");
+            }
+            StorageHelper.InternalStorage.delete(dataFile);
         }
-        StorageHelper.InternalStorage.delete(dataFile);
     }
 
     /**
      * Load wrapper exception data into memory
      *
-     * @param errorId   The associated error UUID
+     * @param errorId The associated error UUID
      * @return The data loaded into memory
      */
     public static byte[] loadWrapperExceptionData(UUID errorId) {
@@ -101,8 +100,7 @@ public class WrapperSdkExceptionManager {
                 sWrapperExceptionDataContainer.put(errorId.toString(), dataBytes);
             }
             return dataBytes;
-        }
-        catch (ClassNotFoundException | IOException e) {
+        } catch (ClassNotFoundException | IOException e) {
             MobileCenterLog.error(Crashes.LOG_TAG, "Cannot access wrapper exception data file " + dataFile.getName(), e);
         }
         return null;
@@ -111,7 +109,7 @@ public class WrapperSdkExceptionManager {
     /**
      * Get a file object for wrapper exception data
      *
-     * @param errorId   The associated error UUID
+     * @param errorId The associated error UUID
      * @return The corresponding file object
      */
     private static File getFile(@NonNull UUID errorId) {

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/ingestion/models/Exception.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/ingestion/models/Exception.java
@@ -48,7 +48,7 @@ public class Exception implements Model {
     /**
      * Name of the wrapper SDK that emitted this exception.
      * Consists of the name of the SDK and the wrapper platform,
-     * e.g. "mobilecentersdk.xamarin", "hockeysdk.cordova".
+     * e.g. "mobilecenter.xamarin", "hockeysdk.cordova".
      */
     private String wrapperSdkName;
 

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
@@ -489,7 +489,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(new File("."));
         when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(Throwable.class))).thenCallRealMethod();
 
-        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(exception).thenReturn(new byte[]{}).thenReturn(exception);
+        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(exception);
 
         Crashes.setListener(new AbstractCrashesListener() {
             @Override

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
@@ -801,7 +801,7 @@ public class CrashesTest {
         assertNull(Crashes.getLastSessionCrashReport());
 
         /*
-         * Deserializing fails twice: processing the log from last time as part of the bulk processing.
+         * De-serializing fails twice: processing the log from last time as part of the bulk processing.
          * And loading that same file for exposing it in getLastErrorReport.
          */
         verifyStatic(times(2));

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerTest.java
@@ -56,7 +56,7 @@ public class WrapperSdkExceptionManagerTest {
     }
 
     @Test
-    public void deleteWrapperExceptionDataWithNullId() throws Exception {
+    public void deleteWrapperExceptionDataWithNullId() {
 
         /* Delete null does nothing. */
         WrapperSdkExceptionManager.deleteWrapperExceptionData(null);
@@ -67,7 +67,7 @@ public class WrapperSdkExceptionManagerTest {
     }
 
     @Test
-    public void deleteWrapperExceptionDataWithMissingId() throws Exception {
+    public void deleteWrapperExceptionDataWithMissingId() {
 
         /* Delete with file not found does nothing. */
         WrapperSdkExceptionManager.deleteWrapperExceptionData(UUID.randomUUID());

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerTest.java
@@ -5,12 +5,10 @@ import com.microsoft.azure.mobile.utils.UUIDUtils;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Mockito;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,16 +19,24 @@ import static junit.framework.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({MobileCenterLog.class, StorageHelper.InternalStorage.class, Crashes.class})
+@PrepareForTest({WrapperSdkExceptionManager.class, MobileCenterLog.class, StorageHelper.InternalStorage.class, Crashes.class})
 public class WrapperSdkExceptionManagerTest {
+
+    @Rule
+    public PowerMockRule rule = new PowerMockRule();
 
     @Before
     public void setUp() {
         mockStatic(StorageHelper.InternalStorage.class);
+        mockStatic(MobileCenterLog.class);
     }
 
     @Test
@@ -40,10 +46,10 @@ public class WrapperSdkExceptionManagerTest {
 
     @Test
     public void loadWrapperExceptionData() throws Exception {
-        PowerMockito.doThrow(new IOException()).when(StorageHelper.InternalStorage.class);
+        doThrow(new IOException()).when(StorageHelper.InternalStorage.class);
         StorageHelper.InternalStorage.readObject(any(File.class));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(UUID.randomUUID()));
-        PowerMockito.doThrow(new ClassNotFoundException()).when(StorageHelper.InternalStorage.class);
+        doThrow(new ClassNotFoundException()).when(StorageHelper.InternalStorage.class);
         StorageHelper.InternalStorage.readObject(any(File.class));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(UUID.randomUUID()));
         assertNull(WrapperSdkExceptionManager.loadWrapperExceptionData(null));
@@ -51,30 +57,73 @@ public class WrapperSdkExceptionManagerTest {
 
     @Test
     public void deleteWrapperExceptionDataWithNullId() throws Exception {
-        WrapperSdkExceptionManager.deleteWrapperExceptionData(null);
-        verifyStatic(Mockito.never());
-        StorageHelper.InternalStorage.delete(any(File.class));
 
-        WrapperSdkExceptionManager.deleteWrapperExceptionData(UUID.randomUUID());
-        verifyStatic(Mockito.never());
+        /* Delete null does nothing. */
+        WrapperSdkExceptionManager.deleteWrapperExceptionData(null);
+        verifyStatic(never());
         StorageHelper.InternalStorage.delete(any(File.class));
+        verifyStatic();
+        MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString());
     }
 
     @Test
-    public void saveWrapperExceptionData() throws IOException {
-        // cannot save with a null uuid
-        WrapperSdkExceptionManager.saveWrapperExceptionData(null, null);
-        verifyStatic(Mockito.never());
-        StorageHelper.InternalStorage.writeObject(any(File.class), anyString());
+    public void deleteWrapperExceptionDataWithMissingId() throws Exception {
 
-        // ok to save null if there is a uuid
-        WrapperSdkExceptionManager.saveWrapperExceptionData(null, UUID.randomUUID()); //save null data
+        /* Delete with file not found does nothing. */
+        WrapperSdkExceptionManager.deleteWrapperExceptionData(UUID.randomUUID());
+        verifyStatic(never());
+        StorageHelper.InternalStorage.delete(any(File.class));
+        verifyStatic(never());
+        MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString());
+    }
+
+    @Test
+    public void deleteWrapperExceptionDataWithLoadingError() throws Exception {
+
+        /* Delete with file that cannot be loaded because invalid content should just log an error. */
+        File file = mock(File.class);
+        whenNew(File.class).withAnyArguments().thenReturn(file);
+        when(file.exists()).thenReturn(true);
+        WrapperSdkExceptionManager.deleteWrapperExceptionData(UUID.randomUUID());
+        verifyStatic();
+        StorageHelper.InternalStorage.delete(any(File.class));
+        verifyStatic();
+        MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString());
+    }
+
+    @Test
+    public void saveWrapperExceptionDataNull() throws IOException {
+
+        /* Cannot save with a null uuid */
+        WrapperSdkExceptionManager.saveWrapperExceptionData(null, null);
+        verifyStatic(never());
+        StorageHelper.InternalStorage.writeObject(any(File.class), anyString());
+        verifyStatic();
+        MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString());
+    }
+
+    @Test
+    public void saveWrapperExceptionDataMissingId() throws IOException {
+
+        /* Ok to save null if there is a uuid */
+        WrapperSdkExceptionManager.saveWrapperExceptionData(null, UUID.randomUUID());
         verifyStatic();
         StorageHelper.InternalStorage.writeObject(any(File.class), any(Serializable.class));
-        
-        PowerMockito.doThrow(new IOException()).when(StorageHelper.InternalStorage.class);
-        StorageHelper.InternalStorage.writeObject(any(File.class), anyString());
+        verifyStatic(never());
+        MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString(), any(IOException.class));
+        verifyStatic(never());
+        MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString());
+    }
+
+    @Test
+    public void saveWrapperExceptionDataFailing() throws IOException {
+
+        /* Save null and test failure. */
+        doThrow(new IOException()).when(StorageHelper.InternalStorage.class);
+        StorageHelper.InternalStorage.writeObject(any(File.class), any(Serializable.class));
         WrapperSdkExceptionManager.saveWrapperExceptionData(null, UUIDUtils.randomUUID());
+        verifyStatic();
+        StorageHelper.InternalStorage.writeObject(any(File.class), anyString());
         verifyStatic();
         MobileCenterLog.error(eq(Crashes.LOG_TAG), anyString(), any(IOException.class));
     }


### PR DESCRIPTION
* Fix a file leak when data could not be read.
* Fix noisy logging when wrapper sdk not used.
* Fix unit tests.